### PR TITLE
Refactor: ShortOTokenActionWithSwap contract size

### DIFF
--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.7.2;
 pragma experimental ABIEncoderV2;
 
-import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import { SafeMath } from '@openzeppelin/contracts/math/SafeMath.sol';
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { SafeERC20 } from '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
@@ -37,7 +36,7 @@ import { RollOverBase } from '../utils/RollOverBase.sol';
  * @author Opyn Team
  */
 
-contract ShortOTokenActionWithSwap is IAction, OwnableUpgradeable, AirswapBase, RollOverBase {
+contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
   using SafeERC20 for IERC20;
   using SafeMath for uint256;
 
@@ -89,7 +88,6 @@ contract ShortOTokenActionWithSwap is IAction, OwnableUpgradeable, AirswapBase, 
 
     _initSwapContract(_swap);
     _initRollOverBase(_opynWhitelist);
-    __Ownable_init();
 
     _openVault(_vaultType);
   }

--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -171,6 +171,7 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
     if (otoken != address(0) && lockedAsset != 0) { 
       return _canSettleVault();
     }
+
     return block.timestamp > rolloverTime + 1 days; 
   }
 
@@ -178,8 +179,8 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
    * @dev open vault with vaultId 1. this should only be performed once when contract is initiated
    */
   function _openVault(uint256 _vaultType) internal {
-
     bytes memory data;
+
     if (_vaultType != 0) {
       data = abi.encode(_vaultType);
     }
@@ -263,7 +264,6 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
    * @dev settle vault 0 and withdraw all locked collateral
    */
   function _settleVault() internal {
-
     IController.ActionArgs[] memory actions = new IController.ActionArgs[](1);
     // this action will always use vault id 1
     actions[0] = IController.ActionArgs(

--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -299,9 +299,8 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
    */
   function _customOTokenCheck(address _nextOToken) internal view override {
     // Can override or replace this.
-     IOToken otokenToCheck = IOToken(_nextOToken);
-     require(_isValidStrike(otokenToCheck.strikePrice()), 'S9');
-     require (_isValidExpiry(otokenToCheck.expiryTimestamp()), 'S10');
+     require(_isValidStrike(IOToken(_nextOToken).strikePrice()), 'S9');
+     require (_isValidExpiry(IOToken(_nextOToken).expiryTimestamp()), 'S10');
     /**
      * e.g.
      * check otoken strike price is lower than current spot price for put.

--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -298,7 +298,7 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
    * this hook is triggered while action owner calls "commitNextOption"
    * so accessing otoken will give u the current otoken. 
    */
-  function _customOTokenCheck(address _nextOToken) internal view override {
+  function _customOTokenCheck(address _nextOToken) internal view {
     // Can override or replace this.
      require(_isValidStrike(IOToken(_nextOToken).strikePrice()), 'S9');
      require (_isValidExpiry(IOToken(_nextOToken).expiryTimestamp()), 'S10');

--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -92,10 +92,8 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
     _openVault(_vaultType);
   }
 
-  modifier onlyVault() {
+  function onlyVault() private view {
     require(msg.sender == vault, "S1");
-
-    _;
   }
 
   /**
@@ -112,7 +110,8 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
   /**
    * @dev the function that the vault will call when the round is over
    */
-  function closePosition() external onlyVault override {
+  function closePosition() external override {
+    onlyVault();
     require(canClosePosition(), 'S2');
     
     if(_canSettleVault()) {
@@ -129,7 +128,8 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
   /**
    * @dev the function that the vault will call when the new round is starting
    */
-  function rolloverPosition() external onlyVault override {
+  function rolloverPosition() external override {
+    onlyVault();
     
     // this function can only be called when it's `Committed`
     _rollOverNextOTokenAndActivate();

--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -141,7 +141,8 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
    * by filling an order on AirSwap.
    * this can only be done in "activated" state. which is achievable by calling `rolloverPosition`
    */
-  function mintAndSellOToken(uint256 _collateralAmount, uint256 _otokenAmount, SwapTypes.Order memory _order) external onlyOwner onlyActivated {
+  function mintAndSellOToken(uint256 _collateralAmount, uint256 _otokenAmount, SwapTypes.Order memory _order) external onlyOwner {
+    onlyActivated();
     require(_order.sender.wallet == address(this), 'S3');
     require(_order.sender.token == otoken, 'S4');
     require(_order.signer.token == address(weth), 'S5');

--- a/contracts/actions/ShortOTokenActionWithSwap.sol
+++ b/contracts/actions/ShortOTokenActionWithSwap.sol
@@ -213,13 +213,12 @@ contract ShortOTokenActionWithSwap is IAction, AirswapBase, RollOverBase {
     uint256[2] memory amounts;
     amounts[0] = wethBalance;
     amounts[1] = 0;
-    uint256 minAmount = 0;
 
     //unwrap weth => eth to deposit on curve
     weth.withdraw(wethBalance);
     // deposit ETH to curve
     require(address(this).balance == wethBalance, 'S8');
-    curve.add_liquidity{value:wethBalance}(amounts, minAmount);
+    curve.add_liquidity{value:wethBalance}(amounts, 0); // minimum amount to deposit is 0 ETH
     uint256 ecrvToDeposit = ecrv.balanceOf(address(this));
 
     // deposit ecrv to stakedao

--- a/contracts/utils/RollOverBase.sol
+++ b/contracts/utils/RollOverBase.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.2;
 pragma experimental ABIEncoderV2;
 
-import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { SafeERC20 } from '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 
@@ -24,7 +24,7 @@ import { SwapTypes } from '../libraries/SwapTypes.sol';
  * @author Opyn Team
  */
 
-contract RollOverBase is OwnableUpgradeable {
+contract RollOverBase is Ownable {
   address public otoken;
   address public nextOToken;
 

--- a/contracts/utils/RollOverBase.sol
+++ b/contracts/utils/RollOverBase.sol
@@ -47,17 +47,14 @@ contract RollOverBase is Ownable {
   }
 
   ActionState public state;
-
   IWhitelist public opynWhitelist;
 
-  modifier onlyCommitted () {
+  function onlyCommitted() private view {
     require(state == ActionState.Committed, "R1");
-    _;
   }
 
-  modifier onlyActivated () {
+  function onlyActivated() public view {
     require(state == ActionState.Activated, "R2");
-    _;
   }
 
 
@@ -80,12 +77,14 @@ contract RollOverBase is Ownable {
     commitStateStart = block.timestamp;
   }
 
-  function _setActionIdle() internal onlyActivated {
+  function _setActionIdle() internal {
+    onlyActivated();
     // wait for the owner to set the next option
     state = ActionState.Idle;
   }
 
-  function _rollOverNextOTokenAndActivate() internal onlyCommitted {
+  function _rollOverNextOTokenAndActivate() internal {
+    onlyCommitted();
     require(block.timestamp - commitStateStart > MIN_COMMIT_PERIOD, "R4");
 
     otoken = nextOToken;

--- a/contracts/utils/RollOverBase.sol
+++ b/contracts/utils/RollOverBase.sol
@@ -31,16 +31,18 @@ contract RollOverBase is Ownable {
   uint256 constant public MIN_COMMIT_PERIOD = 18 hours;
   uint256 public commitStateStart;
 
+/**
+ * Idle: action will go "idle" after the vault closes this position & before the next oToken is committed.
+ *
+ * Committed: owner has already set the next oToken this vault is trading. During this phase, all funds are
+ * already back in the vault and waiting for redistribution. Users who don't agree with the setting of the next
+ * round can withdraw.
+ *
+ * Activated: after vault calls "rollover", the owner can start minting / buying / selling according to each action.
+ */
   enum ActionState {
-    // action will go "idle" after the vault close this position, and before the next otoken is committed.
     Idle,
-
-    // onwer already set the next otoken this vault is trading.
-    // during this phase, all funds are already back in the vault and waiting for re-distribution
-    // users who don't agree with the setting of next round can withdraw.
     Committed,
-
-    // after vault calls "rollover", owner can start minting / buying / selling according to each action.
     Activated
   }
 

--- a/contracts/utils/RollOverBase.sol
+++ b/contracts/utils/RollOverBase.sol
@@ -95,11 +95,5 @@ contract RollOverBase is Ownable {
 
   function _checkOToken(address _nextOToken) private view {
     require(opynWhitelist.isWhitelistedOtoken(_nextOToken), 'R5');
-    _customOTokenCheck(_nextOToken);
   }
-
-  /**
-   * cutom otoken check hook to be overriden by each 
-   */
-  function _customOTokenCheck(address) internal view virtual {}
 }


### PR DESCRIPTION
- refactor: `OwnableUpgradeable` -> `Ownable`: `RollOverBase`
- refactor: remove redundant `Ownable` contract inheritance & import: `ShortOTokenActionWithSwap`
- refactor: convert `modifier` to `private` fn: `ShortOTokenActionWithSwap`
- refactor: hardcode `minAmount` of ETH to deposit in curve pool: `ShortOTokenActionWithSwap`
- refactor: minimize additional variables in `_customOTokenCheck`: `ShortOTokenActionWithSwap`
- refactor: misc - `ShortOTokenActionWithSwap`
- docs: refactor `ActionState` `enum` code comments - `RollOverBase`
- refactor: convert modifiers to `private` & `public` functions: `RollOverBase`
- refactor: remove `internal` `_customOTokenCheck` `override` for now, bring contract size below limit - `RollOverBase`